### PR TITLE
feat: add `testEnabled` flag to support disabling test tasks

### DIFF
--- a/pipelines/CluedIn.Crawler.yml
+++ b/pipelines/CluedIn.Crawler.yml
@@ -23,6 +23,9 @@ parameters:
     type: stepList
     displayName: Additional steps to run after build but before test
     default: []
+  - name: testsEnabled
+    default: true
+    displayName: Set to false to disable test tasks
   - name: postTest
     type: stepList
     displayName: Additional steps to run after test but before pack
@@ -81,39 +84,41 @@ jobs:
           - ${{ each pair in step }}:
               ${{ pair.key }}: ${{ pair.value }}
 
-      - script: dotnet test $(dotnetDefaults)  --no-build /bl:$(logsDir)/test.binlog -r $(testsDir)/Unit --logger trx --collect:"XPlat Code Coverage"
-        displayName: Dotnet Test
+      - ${{ if eq(parameters.testsEnabled, true) }}:
 
-      - ${{ each step in parameters.postTest }}:
-          - ${{ each pair in step }}:
-              ${{ pair.key }}: ${{ pair.value }}
+        - script: dotnet test $(dotnetDefaults) --no-build /bl:$(logsDir)/test.binlog -r $(testsDir)/Unit --logger trx --collect:"XPlat Code Coverage"
+          displayName: Dotnet Test
 
-      - task: PublishTestResults@2
-        displayName: Publish Tests
-        condition: succeededOrFailed()
-        continueOnError: true
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '**/*.trx'
-          searchFolder: $(testsDir)
-          testRunTitle: Unit Tests
+        - ${{ each step in parameters.postTest }}:
+            - ${{ each pair in step }}:
+                ${{ pair.key }}: ${{ pair.value }}
 
-      # REQUIRES: https://marketplace.visualstudio.com/items?itemName=Palmmedia.reportgenerator
-      - task: reportgenerator@4
-        displayName: Generate Coverage Report
-        condition: succeededOrFailed()
-        inputs:
-          reports: '$(testsDir)/**/*.cobertura.xml'
-          targetdir: '$(testsDir)/coveragereport'
-          tag: '$(build.buildnumber)'
+        - task: PublishTestResults@2
+          displayName: Publish Tests
+          condition: succeededOrFailed()
+          continueOnError: true
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '**/*.trx'
+            searchFolder: $(testsDir)
+            testRunTitle: Unit Tests
 
-      - task: PublishCodeCoverageResults@1
-        displayName: Publish Coverage Report
-        condition: succeededOrFailed()
-        inputs:
-          codeCoverageTool: Cobertura
-          summaryFileLocation: '$(testsDir)/coveragereport/Cobertura.xml'
-          reportDirectory: '$(testsDir)/coveragereport'
+        # REQUIRES: https://marketplace.visualstudio.com/items?itemName=Palmmedia.reportgenerator
+        - task: reportgenerator@4
+          displayName: Generate Coverage Report
+          condition: succeededOrFailed()
+          inputs:
+            reports: '$(testsDir)/**/*.cobertura.xml'
+            targetdir: '$(testsDir)/coveragereport'
+            tag: '$(build.buildnumber)'
+
+        - task: PublishCodeCoverageResults@1
+          displayName: Publish Coverage Report
+          condition: succeededOrFailed()
+          inputs:
+            codeCoverageTool: Cobertura
+            summaryFileLocation: '$(testsDir)/coveragereport/Cobertura.xml'
+            reportDirectory: '$(testsDir)/coveragereport'
 
       - script: dotnet pack $(dotnetDefaults) -o $(nugetDir) --no-build /bl:$(logsDir)/pack.binlog
         displayName: Dotnet Pack

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -37,7 +37,16 @@ When added as part of your pipeline, the crawler job will perform the following 
 1. Generate and publish code coverage reports
 1. Run pack on the projects under the given root directory
 1. Publish packed projects as a build asset
-> Users can inject additional steps before build, after build, after test, and after pack
+
+#### Parameters
+A series of parameters are available to modify the template, including:
++ `configuration` - the build configuration
++ `version` - the version to be built
++ `testsEnabled` - enables/disables the inclusion of test functionality
++ Several parameters to _inject_ additional steps
+... and more.
+
+> Please review the [start of the template](CluedIn.Crawler.yml) where parameters are declared
 
 ### Example usage
 ```yaml
@@ -46,4 +55,5 @@ jobs:
     parameters:
       configuration: Release
       version: 1.0.0
+      testsEnabled: false
 ```


### PR DESCRIPTION
By setting `testsEnabled` to false a user can disable the following tasks from being included:
+ Dotnet Test
+ Publish Tests
+ Generate Coverage Report
+ Publish Coverage Report

> The tests are wholly removed from the pipeline - no reporting on or inclusion of the tasks can be seen in the build.